### PR TITLE
Compatability with upcoming ggplot2 version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -23,7 +23,7 @@ Imports:
     assertthat,
     bayesplot,
     dplyr,
-    ggplot2 (>= 3.3.4),
+    ggplot2 (>= 3.4.0),
     ggpubr,
     gtools,
     magrittr,

--- a/R/plot_methods.R
+++ b/R/plot_methods.R
@@ -364,20 +364,28 @@ plot.mix_mode <- function(x, from = x$range[1], to = x$range[2], ...) {
 
 ### ggplot theme
 #' @keywords internal
-theme_gg <- ggplot2::theme_bw() + ggplot2::theme(
-  strip.background = element_blank(),
-  strip.text = element_text(size = 11),
-  title = element_text(size = 11),
-  panel.border = element_blank(),
-  # panel.grid.major=element_blank(),
-  # panel.grid.minor=element_blank(),
-  # legend.key=element_rect(colour="white"),
-  legend.position = "bottom",
-  legend.box.margin = margin(-10, 0, -10, 0),
-  legend.title = element_blank(),
-  legend.text = element_text(size = 11),
-  axis.text = element_text(size = 11),
-  axis.line.y = element_line(colour = "grey", size = 0.5, linetype = "solid"),
-  axis.line.x = element_line(colour = "grey", size = 0.5, linetype = "solid"),
-  plot.title = element_text(hjust = 0.5, size = 12, face = "bold")
-)
+theme_gg <- NULL
+
+.onLoad <- function(...) {
+  theme_gg <<- new_theme_gg()
+}
+
+new_theme_gg <- function() {
+  ggplot2::theme_bw() + ggplot2::theme(
+    strip.background = element_blank(),
+    strip.text = element_text(size = 11),
+    title = element_text(size = 11),
+    panel.border = element_blank(),
+    # panel.grid.major=element_blank(),
+    # panel.grid.minor=element_blank(),
+    # legend.key=element_rect(colour="white"),
+    legend.position = "bottom",
+    legend.box.margin = margin(-10, 0, -10, 0),
+    legend.title = element_blank(),
+    legend.text = element_text(size = 11),
+    axis.text = element_text(size = 11),
+    axis.line.y = element_line(colour = "grey", size = 0.5, linetype = "solid"),
+    axis.line.x = element_line(colour = "grey", size = 0.5, linetype = "solid"),
+    plot.title = element_text(hjust = 0.5, size = 12, face = "bold")
+  )
+}

--- a/R/plot_methods.R
+++ b/R/plot_methods.R
@@ -384,8 +384,8 @@ new_theme_gg <- function() {
     legend.title = element_blank(),
     legend.text = element_text(size = 11),
     axis.text = element_text(size = 11),
-    axis.line.y = element_line(colour = "grey", size = 0.5, linetype = "solid"),
-    axis.line.x = element_line(colour = "grey", size = 0.5, linetype = "solid"),
+    axis.line.y = element_line(colour = "grey", linewidth = 0.5, linetype = "solid"),
+    axis.line.x = element_line(colour = "grey", linewidth = 0.5, linetype = "solid"),
     plot.title = element_text(hjust = 0.5, size = 12, face = "bold")
   )
 }


### PR DESCRIPTION
Hi there,

We've been preparing a new major release for ggplot2 and found an issue during a reverse dependency check.
The issue was that `theme_gg` was being generated at built time and emitted a warning about deprecated elements, which may ruffle CRAN's feathers.
See the following part of the vignette for more information about them built time problem: https://ggplot2.tidyverse.org/articles/ggplot2-in-packages.html#creating-a-new-theme.

To fix this, this PR builds `theme_gg` when the package is loaded, and replaces the deprecated elements. I saw some further test failures that relate to snapshots, but as these don't really relate to ggplot2 as far as I could tell, I've left these alone. You may want to run the tests and inspect this yourself.
You can test your code with the development version of ggplot2 by installing it as follows:

```r
# install.packages("pak")
pak::pak("tidyverse/ggplot2")
```

We aim to release the new ggplot2 version in about 2 weeks, and hope you can submit a fix to CRAN around that time. Hopefully this will inform you in a timely manner.

Best wishes,
Teun